### PR TITLE
bugfix: fixed the issue 'Unable to find expected entry' during graphv…

### DIFF
--- a/docker/devtools/Dockerfile
+++ b/docker/devtools/Dockerfile
@@ -1,3 +1,4 @@
 FROM matthiasnoback/php_workshop_tools_base
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
 RUN apt-get -y update && apt-get install -y graphviz
 RUN curl -LS http://get.sensiolabs.de/deptrac.phar -o deptrac.phar && chmod +x deptrac.phar && mv deptrac.phar /usr/local/bin/deptrac


### PR DESCRIPTION
Some linux jessie mirrors are not reachable anymore.
Small fix to keep the docker function.