### PR TITLE
Suggested changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,19 @@ On most machines the best way to install this project will be to use Docker. If 
 
 #### Getting started
 
-- Make sure the `HOST_UID` and `HOST_GUID` environment variables have been defined:
+- Make sure the `HOST_UID`, `HOST_GUID` and `HOST_PORT` environment variables have been defined:
 
     ```
     export HOST_GID=$(id -g)
     export HOST_UID=$(id -u)
+    export HOST_PORT=8080 # or whatever other port you want
     ```
 
 - Clone this repository (`git clone git@github.com:matthiasnoback/layers-ports-and-adapters-workshop.git`) and `cd` into it.
 - Run `docker-compose pull`.
 - Run `bin/composer.sh install --prefer-dist` to install the project's dependencies.
 - Run `docker-compose up -d` to start the web server.
-- Open <http://localhost/> in a browser. You should see the homepage of the meetup application.
+- Open <http://localhost:8080> (adapt the port to your use case) in a browser. You should see the homepage of the meetup application.
 
 #### Running development tools
 

--- a/bin/composer.sh
+++ b/bin/composer.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker-compose run --rm devtools php -d memory_limit=-1 $(which composer) $@
+docker-compose run --rm devtools /usr/local/bin/composer $@

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         volumes:
             - ./:/opt
         ports:
-            - 80:8080
+            - ${HOST_PORT}:8080
         user: ${HOST_UID}:${HOST_GID}
 
     devtools:


### PR DESCRIPTION
Some suggestions:

 - Use `HOST_PORT` to control which port is used instead of hard-coding port 80.
- Fix `bin/composer.sh` not working: the `$(which composer)` part doesn't run in the container, but on the host and if you don't have composer installed (or you do but the path doesn't match what's in the container), it will fail.